### PR TITLE
Rename to libitk

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "4.12.0" %}
 
 package:
-  name: itk
+  name: libitk
   version: "{{version}}"
 
 source:


### PR DESCRIPTION
Since this package just provides the C++ headers / libraries, it is
renamed to libitk, which would be consistent libxml2, libdap4, libiconv,
libtiff, etc., and facilitates installation of the Python bindings
package with `conda install itk`.