### PR TITLE
Build for osx_arm64 as well

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,3 +6,6 @@ github:
   tooling_branch_name: main
 conda_build:
   pkg_format: '2'
+build_platform:
+  osx_arm64: osx_64
+test: native_and_emulated

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "5.3.0"
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win32 or (win64 and py2k)]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes https://github.com/conda-forge/itk-feedstock/issues/39.


<!--
Please add any other relevant info below:
-->

Despite https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5473 being merged, there was no build for osx_arm64, so let's try adding it to conda-forge.yml and then rebuild.